### PR TITLE
Add application hiding

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,3 +98,8 @@ The URL to an icon representing the app.
 
 ### `apps.<app-name>.url`
 The URL at which the app is hosted, to which the user will be redirected when clicking it.
+
+### `apps.<app-name>.hidden`
+Set to `true` to mark an app as hidden and prevent it being shown to users. 
+
+If an app is fetched from authentik with `auth.fetch`, this will be set to `true` if the app's launch URL is `blank://blank`, as this is how authentik natively hides apps ([docs](https://docs.goauthentik.io/docs/add-secure-apps/applications/manage_apps#hide-applications)).

--- a/src/blobdash/__init__.py
+++ b/src/blobdash/__init__.py
@@ -1,6 +1,6 @@
 import flask as f
 from click import secho
-from pydantic import ValidationError, BaseModel
+from pydantic import ValidationError
 
 
 from .settings import Settings

--- a/src/blobdash/applications.py
+++ b/src/blobdash/applications.py
@@ -14,6 +14,7 @@ class Application:
     url: Optional[str] = None
     icon: Optional[str] = None
     desc: Optional[str] = None
+    hidden: bool = False
 
 
 class ApplicationProvider:

--- a/src/blobdash/auth.py
+++ b/src/blobdash/auth.py
@@ -41,6 +41,10 @@ class AuthentikAuthProvider(AuthProvider):
                 url=app.launch_url,
                 icon=urllib.parse.urljoin(self.host, app.meta_icon),
                 desc=app.meta_description,
+                hidden=(
+                    (parsed_url := urllib.parse.urlparse(app.launch_url)).scheme == "blank"
+                    and parsed_url.netloc == "blank"
+                ),
             )
             for app in list.results
         }

--- a/src/blobdash/settings.py
+++ b/src/blobdash/settings.py
@@ -1,5 +1,4 @@
 from typing import Tuple, Type, Optional, Literal
-from abc import ABCMeta
 
 from pydantic import BaseModel
 from pydantic_extra_types import color

--- a/src/blobdash/templates/index.html.jinja
+++ b/src/blobdash/templates/index.html.jinja
@@ -90,13 +90,15 @@
     </dialog>
     <main>
         {% for app in apps.values() %}
-        <a href="{{ app.url }}">
-            <img src="{{ app.icon }}">
-            <h3>
-                {{ app.name }}
-            </h3>
-            <p>{{ app.desc }}</p>
-        </a>
+            {% if not app.hidden %}
+                <a href="{{ app.url }}">
+                    <img src="{{ app.icon }}">
+                    <h3>
+                        {{ app.name }}
+                    </h3>
+                    <p>{{ app.desc }}</p>
+                </a>
+            {% endif %}
         {% endfor %} 
     </main>
 </body>


### PR DESCRIPTION
This lets applications be hidden from the dashboard, whether via manual configuration in `blobdash.toml` or during the fetch process by setting the launch URL in authentik to `blank://blank`.